### PR TITLE
create separate TB channels for tasks and runs in train_for_eval phase

### DIFF
--- a/src/trainer.py
+++ b/src/trainer.py
@@ -950,11 +950,13 @@ class SamplingMultiTaskTrainer():
         for name in metric_names:
             train_metric = train_metrics.get(name)
             if phase == "main":
-                name = 'pretrain_' + task_name + '/' + task_name + '_' + name
+                name = 'pretrain_' + task_name + '/' + task_name + '_' +name
                 self._TB_train_log.add_scalar(name, train_metric, epoch)
-            if phase == "eval":
+            elif phase == "eval":
                 name = 'train_for_eval_' + task_name + '/' + task_name + '_' + name
                 self._TB_eval_train_log.add_scalar(name, train_metric, epoch)
+            else:
+                raise ValueError('We expect logs either from main or eval phase')
 
     def _metrics_to_tensorboard_val(self, epoch, val_metrics, phase):
         """
@@ -968,9 +970,11 @@ class SamplingMultiTaskTrainer():
             if phase == 'main':
                 name = 'pretrain_' + name.split('_')[0] + '/' + name
                 self._TB_validation_log.add_scalar(name, val_metric, epoch)
-            if phase == 'eval':
+            elif phase == 'eval':
                 name = 'train_for_eval_' + name.split('_')[0] + '/' + name
                 self._TB_eval_validation_log.add_scalar(name, val_metric, epoch)
+            else:
+                raise ValueError('We expect logs either from main or eval phase')
 
     @classmethod
     def from_params(cls, model, serialization_dir, params):


### PR DESCRIPTION
We now plot the curves in different ways for pretraining and train_for_eval phases. In the pretraining phase, we create two logging channels (train and val) which contain logs for every training tasks. Every task will have its own tab with plots relevant to that task.  
In train_for_eval phase, we create 2 separate channels for every task and every run (the run is indexed by a timestamp). The reason for this is that, unlike in the pretraining phase, when we stop and resume training in train_for_eval phase, the counter (n_pass) starts from 0 again. If we would plot to the same channel it would create a conflict with old logs and the curve would cross itself. I'm attaching a print screen of TensorBoard. In the left pane, the first two channels correspond to pretraining phase and they populate the first 4 tabs in the right pane. The rest corresponds to the train_for_eval phase. For sts-b, you can see plots for 2 different runs (each having train and val curves).
![screenshot from 2018-09-07 20-06-06](https://user-images.githubusercontent.com/425223/45254028-b9388c00-b370-11e8-9c02-19e728285a09.png)
