### PR TITLE
Fix split script, add nonterminal & pos tasks

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -409,6 +409,8 @@ edges-constituent-ontonotes = ${edges-tmpl} {
     max_vals = 250
     val_interval = 1000
 }
+edges-pos-ontonotes = ${edges-constituent-ontonotes}
+edges-nonterminal-ontonotes = ${edges-constituent-ontonotes}
 
 // These tasks are still very slow. TODO: Debug.
 edges-ccg-tag = ${edges-tmpl}

--- a/probing/split_constituent_data.py
+++ b/probing/split_constituent_data.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+# Helper script to split constituent data into POS and nonterminal groups.
+#
+# TODO to integrate this into the OntoNotes processing script to generate in
+# one shot.
+#
+# Usage:
+#  python split_constituent_data.py /path/to/edge/probing/data/*.json
+
+import sys
+import os
+import copy
+import json
+from tqdm import tqdm
+
+import logging as log
+log.basicConfig(format='%(asctime)s: %(message)s',
+                datefmt='%m/%d %I:%M:%S %p', level=log.INFO)
+
+from src import utils
+from src import retokenize
+
+
+def split_record(record):
+    pos_record = copy.deepcopy(record)
+    non_record = copy.deepcopy(record)
+
+    pos_record['targets'] = [t for t in record['targets']
+                             if t['info']['height'] == 1]
+    non_record['targets'] = [t for t in record['targets']
+                             if t['info']['height'] > 1]
+    return (pos_record, non_record)
+
+def split_file(fname):
+    pieces = fname.split(".json", 1)
+    new_pos_name = pieces[0] + ".pos.json" + pieces[1]
+    new_non_name = pieces[0] + ".nonterminal.json" + pieces[1]
+    log.info("Processing file: %s", fname)
+    record_iter = list(utils.load_json_data(fname))
+    log.info("  saving to %s and %s", new_pos_name, new_non_name)
+    pos_fd = open(new_pos_name, 'w')
+    non_fd = open(new_non_name, 'w')
+    for record in tqdm(record_iter):
+        pos_record, non_record = split_record(record)
+        pos_fd.write(json.dumps(pos_record))
+        pos_fd.write("\n")
+        non_fd.write(json.dumps(non_record))
+        non_fd.write("\n")
+
+
+def main(args):
+    for fname in args:
+        split_file(fname)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+    sys.exit(0)

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -358,6 +358,20 @@ class PairClassificationTask(ClassificationTask):
                    'val': "consts_ontonotes_en_dev.json",
                    'test': "consts_ontonotes_en_test.json",
                }, single_sided=True)
+@register_task('edges-pos-ontonotes',
+               rel_path='edges/ontonotes-constituents',
+               label_file="labels.pos.txt", files_by_split={
+                   'train': "consts_ontonotes_en_train.pos.json",
+                   'val': "consts_ontonotes_en_dev.pos.json",
+                   'test': "consts_ontonotes_en_test.pos.json",
+               }, single_sided=True)
+@register_task('edges-nonterminal-ontonotes',
+               rel_path='edges/ontonotes-constituents',
+               label_file="labels.nonterminal.txt", files_by_split={
+                   'train': "consts_ontonotes_en_train.nonterminal.json",
+                   'val': "consts_ontonotes_en_dev.nonterminal.json",
+                   'test': "consts_ontonotes_en_test.nonterminal.json",
+               }, single_sided=True)
 # CCG tagging (tokens only).
 @register_task('edges-ccg-tag', rel_path='edges/ccg_tag',
                label_file="labels.txt", files_by_split={


### PR DESCRIPTION
Helper script to split constituent data into nonterminals and POS, and configs for these tasks.

TODO to just merge this functionality into the original script that produces the constituent data from OntoNotes. But would prefer to check this in for now since it works, and then streamline things later.