### PR TITLE
Edge probing: UD data code & instructions

### DIFF
--- a/probing/data/README.md
+++ b/probing/data/README.md
@@ -147,29 +147,25 @@ Run:
 
 Tasks: `edges-dep-labeling-ewt`
 
-Download the EWT corpus for Universal Dependencies from [here](https://github.com/UniversalDependencies/UD_English-EWT/tree/master). The specific files that you need are `en_ewt-ud-dev.conllu`, `en_ewt-ud-test.conllu`, and `en_ewt-ud-train.conllu`.
+Run:
+```
+./get_ud_data.sh $JIANT_DATA_DIR/edges/dep_ewt
+```
 
-Run the following three lines (you may need to modify the paths to the downloaded `.conllu` files):
-```
-python ud_to_json.py UD_English-EWT/en_ewt-ud-dev.conllu
-python ud_to_json.py UD_English-EWT/en_ewt-ud-test.conllu
-python ud_to_json.py UD_English-EWT/en_ewt-ud-train.conllu
-```
-You should now see files named `en_ewt-ud-dev.json`, `en_ewt-ud-test.json`, and `en_ewt-ud-train.json` in the directory where the original data files were downloaded. Here is an example of one of the entries in the resulting file:
+This downloads the UD treebank and converts the conllu format to the edge probing format. Entries should look similar to this:
 
 ```
 {
-  "text": "This only serves their purposes .", 
+  "text": "This only serves their purposes .",
   "targets": [
-    {"span1": [0, 1], "span2": [2, 3], "label": "nsubj"}, 
-    {"span1": [1, 2], "span2": [2, 3], "label": "advmod"}, 
-    {"span1": [2, 3], "span2": [2, 3], "label": "root"}, 
-    {"span1": [3, 4], "span2": [4, 5], "label": "nmod:poss"}, 
-    {"span1": [4, 5], "span2": [2, 3], "label": "obj"}, 
+    {"span1": [0, 1], "span2": [2, 3], "label": "nsubj"},
+    {"span1": [1, 2], "span2": [2, 3], "label": "advmod"},
+    {"span1": [2, 3], "span2": [2, 3], "label": "root"},
+    {"span1": [3, 4], "span2": [4, 5], "label": "nmod:poss"},
+    {"span1": [4, 5], "span2": [2, 3], "label": "obj"},
     {"span1": [5, 6], "span2": [2, 3], "label": "punct"}
-  ], 
+  ],
   "info": {"source": "UD_English-EWT"}
 }
 ```
 
-Each element of `targets` represents one dependency arc. For example, the first element shows that there is an arc between the span going from index 0 to index 1 (i.e. the word "This") and the span going from index 2 to index 3 (i.e. the word "serves"), and that dependency arc has the label "nsubj." The task is to provide the correct labels for all of these dependency arcs.

--- a/probing/data/README.md
+++ b/probing/data/README.md
@@ -152,20 +152,4 @@ Run:
 ./get_ud_data.sh $JIANT_DATA_DIR/edges/dep_ewt
 ```
 
-This downloads the UD treebank and converts the conllu format to the edge probing format. Entries should look similar to this:
-
-```
-{
-  "text": "This only serves their purposes .",
-  "targets": [
-    {"span1": [0, 1], "span2": [2, 3], "label": "nsubj"},
-    {"span1": [1, 2], "span2": [2, 3], "label": "advmod"},
-    {"span1": [2, 3], "span2": [2, 3], "label": "root"},
-    {"span1": [3, 4], "span2": [4, 5], "label": "nmod:poss"},
-    {"span1": [4, 5], "span2": [2, 3], "label": "obj"},
-    {"span1": [5, 6], "span2": [2, 3], "label": "punct"}
-  ],
-  "info": {"source": "UD_English-EWT"}
-}
-```
-
+This downloads the UD treebank and converts the conllu format to the edge probing format.

--- a/probing/data/README.md
+++ b/probing/data/README.md
@@ -143,9 +143,33 @@ Run:
 ./get_dpr_data.sh $JIANT_DATA_DIR/edges/dpr
 ```
 
-
-## Universal Dependencies (TODO: Tom)
+## Universal Dependencies
 
 Tasks: `edges-dep-labeling-ewt`
 
-**TODO(Tom):** fill this in.
+Download the EWT corpus for Universal Dependencies from [here](https://github.com/UniversalDependencies/UD_English-EWT/tree/master). The specific files that you need are `en_ewt-ud-dev.conllu`, `en_ewt-ud-test.conllu`, and `en_ewt-ud-train.conllu`.
+
+Run the following three lines (you may need to modify the paths to the downloaded `.conllu` files):
+```
+python ud_to_json.py UD_English-EWT/en_ewt-ud-dev.conllu
+python ud_to_json.py UD_English-EWT/en_ewt-ud-test.conllu
+python ud_to_json.py UD_English-EWT/en_ewt-ud-train.conllu
+```
+You should now see files named `en_ewt-ud-dev.json`, `en_ewt-ud-test.json`, and `en_ewt-ud-train.json` in the directory where the original data files were downloaded. Here is an example of one of the entries in the resulting file:
+
+```
+{
+  "text": "This only serves their purposes .", 
+  "targets": [
+    {"span1": [0, 1], "span2": [2, 3], "label": "nsubj"}, 
+    {"span1": [1, 2], "span2": [2, 3], "label": "advmod"}, 
+    {"span1": [2, 3], "span2": [2, 3], "label": "root"}, 
+    {"span1": [3, 4], "span2": [4, 5], "label": "nmod:poss"}, 
+    {"span1": [4, 5], "span2": [2, 3], "label": "obj"}, 
+    {"span1": [5, 6], "span2": [2, 3], "label": "punct"}
+  ], 
+  "info": {"source": "UD_English-EWT"}
+}
+```
+
+Each element of `targets` represents one dependency arc. For example, the first element shows that there is an arc between the span going from index 0 to index 1 (i.e. the word "This") and the span going from index 2 to index 3 (i.e. the word "serves"), and that dependency arc has the label "nsubj." The task is to provide the correct labels for all of these dependency arcs.

--- a/probing/data/get_ud_data.sh
+++ b/probing/data/get_ud_data.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+TARGET_DIR=$1
+
+THIS_DIR=$(realpath $(dirname $0))
+
+set -e
+if [ ! -d $TARGET_DIR ]; then
+  mkdir $TARGET_DIR
+fi
+
+function fetch_data() {
+  mkdir -p $TARGET_DIR/raw
+  pushd $TARGET_DIR/raw
+
+  # Univeral Dependencies 2.2 for English Web Treebank (ewt) source text.
+  wget https://github.com/UniversalDependencies/UD_English-EWT/archive/r2.2.tar.gz
+  mkdir ud
+  tar -zxvf r2.2.tar.gz -C ud
+
+  # # Universal Dependencies v2.3 data
+  # git clone https://github.com/UniversalDependencies/UD_English-EWT.git $TARGET_DIR/raw
+
+  popd
+}
+
+# fetch_data
+
+# Convert UD to edge probing format.
+python $THIS_DIR/ud_to_json.py \
+  -i $TARGET_DIR/raw/ud/UD_English-EWT-r2.2/en_ewt-ud-*.conllu \
+  -o $TARGET_DIR
+
+# # Join UD with protorole annotations.
+# python $THIS_DIR/convert-spr2.py --src_dir $TARGET_DIR/raw -o $TARGET_DIR
+
+# Print dataset stats for sanity-check.
+# python ${THIS_DIR%jiant*}/jiant/probing/edge_data_stats.py -i $TARGET_DIR/*.json

--- a/probing/data/ud_to_json.py
+++ b/probing/data/ud_to_json.py
@@ -1,0 +1,53 @@
+import sys
+
+# Converts CoNLL format into the JSON format needed for edge probing
+fi = open(sys.argv[1], "r")
+fo = open(sys.argv[1].split(".")[0] + ".json", "w")
+
+prev_line = "FILLER"
+word_lines = []
+examples = []
+
+for line in fi:
+	example_good = 1
+	if len(prev_line) < 3:
+		spans = []
+		words = []
+		
+		for word_line in word_lines:
+			#print(word_line)
+			parts = word_line.split('\t')
+			words.append(parts[1].replace('"', '\\"'))
+			if "." not in parts[0]:
+				this_id = int(parts[0])
+				this_head = int(parts[6])
+			else:
+				example_good = 0
+				this_id = 0
+				this_head = 0
+			if this_head == 0:
+				this_head = this_id
+			deprel = parts[7]
+			#spans.append('{ "span1": [' + str(this_id - 1) + ',' + str(this_id) + '], "span2": [' + str(this_head - 1) + ',' + str(this_head) + '], "label": "' + deprel + '" }')
+			spans.append('{"span1": [' + str(this_id - 1) + ', ' + str(this_id) + '], "span2": [' + str(this_head - 1) + ', ' + str(this_head) + '], "label": "' + deprel + '"}')
+
+
+		#examples.append('{\n\t"text": "' + " ".join(words) + '",\n\t"targets": [\n\t' + "\n\t".join(spans) + '\n\t],\n\t"info": { "source": "UD_English-GUM" }\n}')		
+		
+		if example_good:
+			examples.append('{"text": "' + " ".join(words) + '", "targets": [' + ", ".join(spans) + '], "info": {"source": "UD_English-EWT"}}')		
+
+
+
+		word_lines = []
+		
+	
+	elif line[0] != "#" and len(line.strip()) > 1:
+		word_lines.append(line)
+		
+	prev_line = line.strip()
+
+
+for example in examples:
+	#fo.write(example + "\n\n")
+	fo.write(example + "\n")

--- a/probing/data/ud_to_json.py
+++ b/probing/data/ud_to_json.py
@@ -22,6 +22,7 @@ import pandas as pd
 import conllu
 
 def convert_ud_file(fd):
+    #TODO(Tom): refactor to use conllu to parse file
     prev_line = "FILLER"
     word_lines = []
     examples = []

--- a/probing/data/ud_to_json.py
+++ b/probing/data/ud_to_json.py
@@ -22,6 +22,14 @@ import pandas as pd
 import conllu
 
 def convert_ud_file(fd):
+    """Convert a UD file to a list of records in edge probing format.
+
+    Args:
+        fd: file-like object or list of lines
+
+    Returns:
+        list(dict) of edge probing records
+    """
     #TODO(Tom): refactor to use conllu to parse file
     prev_line = "FILLER"
     word_lines = []

--- a/probing/data/ud_to_json.py
+++ b/probing/data/ud_to_json.py
@@ -1,53 +1,92 @@
+#!/usr/bin/env python
+
+# Script to convert UD English Web Treebank (EWT) data intoa
+# edge probing format for dependency parsing.
+#
+# Usage:
+#   ./ud_to_json.py -i <ud_release_dir>/en_ewt-ud-*.conllu \
+#       -o /path/to/probing/data/ud_ewt
+
 import sys
+import os
+import json
+import argparse
 
-# Converts CoNLL format into the JSON format needed for edge probing
-fi = open(sys.argv[1], "r")
-fo = open(sys.argv[1].split(".")[0] + ".json", "w")
+import logging as log
+log.basicConfig(format='%(asctime)s: %(message)s',
+                datefmt='%m/%d %I:%M:%S %p', level=log.INFO)
 
-prev_line = "FILLER"
-word_lines = []
-examples = []
+import utils
+import pandas as pd
 
-for line in fi:
-	example_good = 1
-	if len(prev_line) < 3:
-		spans = []
-		words = []
-		
-		for word_line in word_lines:
-			#print(word_line)
-			parts = word_line.split('\t')
-			words.append(parts[1].replace('"', '\\"'))
-			if "." not in parts[0]:
-				this_id = int(parts[0])
-				this_head = int(parts[6])
-			else:
-				example_good = 0
-				this_id = 0
-				this_head = 0
-			if this_head == 0:
-				this_head = this_id
-			deprel = parts[7]
-			#spans.append('{ "span1": [' + str(this_id - 1) + ',' + str(this_id) + '], "span2": [' + str(this_head - 1) + ',' + str(this_head) + '], "label": "' + deprel + '" }')
-			spans.append('{"span1": [' + str(this_id - 1) + ', ' + str(this_id) + '], "span2": [' + str(this_head - 1) + ', ' + str(this_head) + '], "label": "' + deprel + '"}')
+import conllu
 
+def convert_ud_file(fd):
+    prev_line = "FILLER"
+    word_lines = []
+    examples = []
 
-		#examples.append('{\n\t"text": "' + " ".join(words) + '",\n\t"targets": [\n\t' + "\n\t".join(spans) + '\n\t],\n\t"info": { "source": "UD_English-GUM" }\n}')		
-		
-		if example_good:
-			examples.append('{"text": "' + " ".join(words) + '", "targets": [' + ", ".join(spans) + '], "info": {"source": "UD_English-EWT"}}')		
+    for line in fd:
+        example_good = 1
+        if len(prev_line) < 3:
+            spans = []
+            words = []
 
+            for word_line in word_lines:
+                parts = word_line.split('\t')
+                words.append(parts[1].replace('"', '\\"'))
+                if "." not in parts[0]:
+                    this_id = int(parts[0])
+                    this_head = int(parts[6])
+                else:
+                    example_good = 0
+                    this_id = 0
+                    this_head = 0
+                if this_head == 0:
+                    this_head = this_id
+                deprel = parts[7]
+                spans.append('{"span1": [' + str(this_id - 1) + ', ' + str(this_id) + '], "span2": [' + str(this_head - 1) + ', ' + str(this_head) + '], "label": "' + deprel + '"}')
 
+            if example_good:
+                examples.append('{"text": "' + " ".join(words) + '", "targets": [' + ", ".join(spans) + '], "info": {"source": "UD_English-EWT"}}')
 
-		word_lines = []
-		
-	
-	elif line[0] != "#" and len(line.strip()) > 1:
-		word_lines.append(line)
-		
-	prev_line = line.strip()
+            word_lines = []
 
 
-for example in examples:
-	#fo.write(example + "\n\n")
-	fo.write(example + "\n")
+        elif line[0] != "#" and len(line.strip()) > 1:
+            word_lines.append(line)
+
+        prev_line = line.strip()
+
+    # Stopgap: make sure the JSON is valid.
+    return [json.loads(e) for e in examples]
+
+
+def main(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', dest="input_files", type=str, nargs="+",
+                        help="Input file(s), e.g. en_ewt-ud-*.conllu")
+    parser.add_argument('-o', dest='output_dir', type=str, required=True,
+                        help="Output directory, e.g. /path/to/edges/data/ud_ewt")
+    args = parser.parse_args(args)
+
+    if not os.path.isdir(args.output_dir):
+        os.mkdir(args.output_dir)
+
+    for filename in args.input_files:
+        with open(filename) as fd:
+            records = convert_ud_file(fd)
+        stats = utils.EdgeProbingDatasetStats()
+        records = stats.passthrough(records)
+        target_basename = os.path.basename(filename).replace(".conllu", ".json")
+        target_fname = os.path.join(args.output_dir, target_basename)
+        utils.write_json_data(target_fname, records)
+        log.info("Wrote examples to %s", target_fname)
+        log.info(stats.format())
+
+    log.info("Done!")
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+    sys.exit(0)
+


### PR DESCRIPTION
Cherry-picked from `edgeprobe_docs` to include the UD code only. Relative to that branch, also refactored argument handing & wrapper script for consistency with other datasets.