### PR TITLE
Remap edge probing configs to use JIANT_PROJECT_PREFIX

### DIFF
--- a/config/edgeprobe_bare.conf
+++ b/config/edgeprobe_bare.conf
@@ -6,7 +6,7 @@
 // This imports the defaults, which can be overridden below.
 include "defaults.conf"  // relative path to this file
 
-project_dir = ${NFS_PROJECT_PREFIX}
+project_dir = ${JIANT_PROJECT_PREFIX}
 exp_name = ""  // configure this
 run_name = "run"  // configure this
 

--- a/config/edgeprobe_cove.conf
+++ b/config/edgeprobe_cove.conf
@@ -6,7 +6,7 @@
 // This imports the defaults, which can be overridden below.
 include "defaults.conf"  // relative path to this file
 
-project_dir = ${NFS_PROJECT_PREFIX}
+project_dir = ${JIANT_PROJECT_PREFIX}
 exp_name = ""  // configure this
 run_name = "run"  // configure this
 

--- a/config/edgeprobe_existing.conf
+++ b/config/edgeprobe_existing.conf
@@ -10,7 +10,7 @@
 // Override paths from params.conf, since these might point to paths on a
 // different system.
 global_ro_exp_dir = "/nfs/jsalt/share/exp/default"
-project_dir = ${JIANT_PROJECT_PREFIX}  // for export to NFS
+project_dir = ${JIANT_PROJECT_PREFIX}
 data_dir = ${JIANT_DATA_DIR}  // required - should point to data on NFS.
 
 // parameters you will need to set via overrides

--- a/config/edgeprobe_existing.conf
+++ b/config/edgeprobe_existing.conf
@@ -10,7 +10,7 @@
 // Override paths from params.conf, since these might point to paths on a
 // different system.
 global_ro_exp_dir = "/nfs/jsalt/share/exp/default"
-project_dir = ${NFS_PROJECT_PREFIX}  // for export to NFS
+project_dir = ${JIANT_PROJECT_PREFIX}  // for export to NFS
 data_dir = ${JIANT_DATA_DIR}  // required - should point to data on NFS.
 
 // parameters you will need to set via overrides

--- a/config/edgeprobe_glove.conf
+++ b/config/edgeprobe_glove.conf
@@ -7,7 +7,7 @@
 // This imports the defaults, which can be overridden below.
 include "defaults.conf"  // relative path to this file
 
-project_dir = ${NFS_PROJECT_PREFIX}
+project_dir = ${JIANT_PROJECT_PREFIX}
 exp_name = ""  // configure this
 run_name = "run"  // configure this
 

--- a/config/edgeprobe_openai.conf
+++ b/config/edgeprobe_openai.conf
@@ -6,7 +6,7 @@
 // This imports the defaults, which can be overridden below.
 include "defaults.conf"  // relative path to this file
 
-project_dir = ${NFS_PROJECT_PREFIX}
+project_dir = ${JIANT_PROJECT_PREFIX}
 exp_name = ""  // configure this
 run_name = "run"  // default
 

--- a/config/edgeprobe_train.conf
+++ b/config/edgeprobe_train.conf
@@ -6,7 +6,7 @@
 // This imports the defaults, which can be overridden below.
 include "defaults.conf"  // relative path to this file
 
-project_dir = ${NFS_PROJECT_PREFIX}
+project_dir = ${JIANT_PROJECT_PREFIX}
 exp_name = ""  // configure this
 run_name = "run"  // configure this
 


### PR DESCRIPTION
This makes it easier to debug locally, since it'll use an experiment directory
in the user's home directory instead of on NFS. Kubernetes runs are unaffected
since JIANT_PROJECT_PREFIX and NFS_PROJECT_PREFIX are the same in that
environment.