### PR TITLE
Remove odd warning in comment.

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -110,9 +110,9 @@ optimizer = adam  // Optimizer. All valid AllenNLP options are available, includ
 lr = 0.0001  // Initial learning rate.
 min_lr = 0.000001  // Minimum learning rate. Training will stop when our explicit LR decay lowers the LR below this point.
 max_grad_norm = 5.0  // Maximum gradient norm, for use in clipping.
-lr_patience = 1  // [Uninformative name alert!] Patience to use (in validation checks) before decaying the learning rate.
-                   // Learning rate will decay after lr_patience + 1 validation checks have completed with no improvement
-                   // in validation score.
+lr_patience = 1  // Patience to use (in validation checks) before decaying the learning rate.
+                 // Learning rate will decay after lr_patience + 1 validation checks have completed with no improvement
+                 // in validation score.
 lr_decay_factor = 0.5  // Factor by which to decay LR (multiplicative) when lr_patience is reached.
 scheduler_threshold = 0.0001  // Threshold used in deciding when to lower learning rate.
 warmup = 4000  // Number of warmup steps for custom transformer LR schedule.


### PR DESCRIPTION
I think this warning was left over from before a big name change. Merge when approved.