### PR TITLE
Remove pooler from_params attribute + refactor pair sentence attention

### DIFF
--- a/config/defaults.conf
+++ b/config/defaults.conf
@@ -255,6 +255,8 @@ dropout_embs = ${dropout}  // Dropout rate for embeddings, same as above by defa
 // are set here.
 
 // Model
+pool_type = max // The type of pooling to aggregate sequences of vectors into a single vector.
+                // Options: first, last, max, mean.
 classifier = mlp  // The type of the final layer(s) in classification and regression tasks.
                   // Options:
                   //   log_reg: Softmax layer with no additional hidden layer.

--- a/src/models.py
+++ b/src/models.py
@@ -388,10 +388,8 @@ def build_task_specific_modules(task, model, d_sent, d_emb, vocab, embedder, arg
     if isinstance(task, SingleClassificationTask):
         module = build_single_sentence_module(task, d_sent, task_params)
         setattr(model, '%s_mdl' % task.name, module)
-    elif isinstance(task, (PairClassificationTask, PairRegressionTask,
-                           PairOrdinalRegressionTask)):
-        module = build_pair_sentence_module(task, d_sent, model, vocab,
-                                            task_params)
+    elif isinstance(task, (PairClassificationTask, PairRegressionTask, PairOrdinalRegressionTask)):
+        module = build_pair_sentence_module(task, d_sent, model, task_params)
         setattr(model, '%s_mdl' % task.name, module)
     elif isinstance(task, LanguageModelingTask):
         d_sent = args.d_hid + (args.skip_embs * d_emb)
@@ -500,6 +498,7 @@ def build_image_sent_module(task, d_inp, params):
 
 def build_single_sentence_module(task, d_inp, params):
     ''' Build a single classifier '''
+    pool_type = "first" # params["pool_type"]
     pooler = Pooler(d_inp, project=True, d_proj=params['d_proj'], pool_type=pool_type)
     classifier = Classifier.from_params(params['d_proj'], task.n_classes, params)
     return SingleClassifier(pooler, classifier)
@@ -522,7 +521,7 @@ def build_pair_sentence_module(task, d_inp, model, params):
         pooler = Pooler(d_inp=params["d_hid_attn"], d_proj=params["d_hid_attn"], project=False)
         d_out = params["d_hid_attn"] * 2
     else:
-        pooler = Pooler(d_inp=d_inp, project=True, d_proj=params["d_proj"], project=True)
+        pooler = Pooler(d_inp=d_inp, project=True, d_proj=params["d_proj"])
         d_out = params["d_proj"]
 
     if params["shared_pair_attn"]:

--- a/src/models.py
+++ b/src/models.py
@@ -487,47 +487,42 @@ def get_task_specific_params(args, task_name):
 
 def build_reddit_module(task, d_inp, params):
     ''' Build a single classifier '''
-    pooler = Pooler.from_params(d_inp, params['d_proj'])
+    pooler = Pooler(d_inp, d_proj=params['d_proj'])
     dnn_ResponseModel = nn.Sequential(nn.Linear(params['d_proj'], params['d_proj']),
-                                      nn.Tanh(), nn.Linear(params['d_proj'], params['d_proj']),
-                                      )
-    #classifier = Classifier.from_params(params['d_proj'], task.n_classes, params)
+                                      nn.Tanh(), nn.Linear(params['d_proj'], params['d_proj']))
     return pooler, dnn_ResponseModel
 
 
 def build_image_sent_module(task, d_inp, params):
-    pooler = Pooler.from_params(d_inp, params['d_proj'])
+    pooler = Pooler(d_inp, d_proj=params['d_proj'])
     return pooler
 
 
 def build_single_sentence_module(task, d_inp, params):
     ''' Build a single classifier '''
-    pooler = Pooler.from_params(d_inp, params['d_proj'])
+    pooler = Pooler(d_inp, project=True, d_proj=params['d_proj'], pool_type=pool_type)
     classifier = Classifier.from_params(params['d_proj'], task.n_classes, params)
     return SingleClassifier(pooler, classifier)
 
 
-def build_pair_sentence_module(task, d_inp, model, vocab, params):
+def build_pair_sentence_module(task, d_inp, model, params):
     ''' Build a pair classifier, shared if necessary '''
 
     def build_pair_attn(d_in, use_attn, d_hid_attn):
         ''' Build the pair model '''
-        if not use_attn:
-            pair_attn = None
-        else:
-            d_inp_model = 2 * d_in
-            modeling_layer = s2s_e.by_name('lstm').from_params(
-                Params({'input_size': d_inp_model, 'hidden_size': d_hid_attn,
-                        'num_layers': 1, 'bidirectional': True}))
-            pair_attn = AttnPairEncoder(vocab, modeling_layer,
-                                        dropout=params["dropout"])
+        d_inp_model = 2 * d_in
+        modeling_layer = s2s_e.by_name('lstm').from_params(
+            Params({'input_size': d_inp_model, 'hidden_size': d_hid_attn,
+                    'num_layers': 1, 'bidirectional': True}))
+        pair_attn = AttnPairEncoder(model.vocab, modeling_layer,
+                                    dropout=params["dropout"])
         return pair_attn
 
     if params["attn"]:
-        pooler = Pooler.from_params(params["d_hid_attn"], params["d_hid_attn"], project=False)
+        pooler = Pooler(d_inp=params["d_hid_attn"], d_proj=params["d_hid_attn"], project=False)
         d_out = params["d_hid_attn"] * 2
     else:
-        pooler = Pooler.from_params(d_inp, params["d_proj"], project=True)
+        pooler = Pooler(d_inp=d_inp, project=True, d_proj=params["d_proj"], project=True)
         d_out = params["d_proj"]
 
     if params["shared_pair_attn"]:
@@ -537,7 +532,7 @@ def build_pair_sentence_module(task, d_inp, model, vocab, params):
         else:
             pair_attn = model.pair_attn
     else:
-        pair_attn = build_pair_attn(d_inp, params["attn"], params["d_hid_attn"])
+        pair_attn = None
 
     n_classes = task.n_classes if hasattr(task, 'n_classes') else 1
     classifier = Classifier.from_params(4 * d_out, n_classes, params)

--- a/src/models.py
+++ b/src/models.py
@@ -492,7 +492,8 @@ def build_reddit_module(task, d_inp, params):
 
 
 def build_image_sent_module(task, d_inp, params):
-    pooler = Pooler(project=True, d_inp=d_inp, d_proj=params['d_proj']) return pooler
+    pooler = Pooler(project=True, d_inp=d_inp, d_proj=params['d_proj'])
+    return pooler
 
 
 def build_single_sentence_module(task, d_inp, params):

--- a/src/models.py
+++ b/src/models.py
@@ -532,7 +532,7 @@ def build_pair_sentence_module(task, d_inp, model, params):
         else:
             pair_attn = model.pair_attn
     elif params["attn"]: # non-shared attn
-        build_pair_attn(d_inp, params["d_hid_attn"])
+        pair_attn = build_pair_attn(d_inp, params["d_hid_attn"])
     else: # no attn
         pair_attn = None
 

--- a/src/models.py
+++ b/src/models.py
@@ -498,7 +498,7 @@ def build_image_sent_module(task, d_inp, params):
 
 def build_single_sentence_module(task, d_inp, params):
     ''' Build a single classifier '''
-    pool_type = "first" # params["pool_type"]
+    pool_type = "max"
     pooler = Pooler(d_inp, project=True, d_proj=params['d_proj'], pool_type=pool_type)
     classifier = Classifier.from_params(params['d_proj'], task.n_classes, params)
     return SingleClassifier(pooler, classifier)

--- a/src/modules/modules.py
+++ b/src/modules/modules.py
@@ -268,10 +268,6 @@ class Pooler(nn.Module):
             seq_emb = proj_seq[:,0]
         return seq_emb
 
-    @classmethod
-    def from_params(cls, d_inp, d_proj, project=True):
-        return cls(d_inp, d_proj=d_proj, project=project)
-
 
 class Classifier(nn.Module):
     ''' Logistic regression or MLP classifier '''

--- a/src/modules/modules.py
+++ b/src/modules/modules.py
@@ -245,7 +245,7 @@ class BoWSentEncoder(Model):
 class Pooler(nn.Module):
     ''' Do pooling, possibly with a projection beforehand '''
 
-    def __init__(self, d_inp, project=True, d_proj=512, pool_type='max'):
+    def __init__(self, project=True, d_inp=512, d_proj=512, pool_type='max'):
         super(Pooler, self).__init__()
         self.project = nn.Linear(d_inp, d_proj) if project else lambda x: x
         self.pool_type = pool_type

--- a/src/modules/seq2seq_decoder.py
+++ b/src/modules/seq2seq_decoder.py
@@ -68,8 +68,7 @@ class Seq2SeqDecoder(Model):
         self._target_embedder = Embedding(num_classes, self._target_embedding_dim)
 
         # Used to get an initial hidden state from the encoder states
-        self._sent_pooler = Pooler.from_params(
-            d_inp=input_dim, d_proj=decoder_hidden_size, project=True)
+        self._sent_pooler = Pooler(d_inp=input_dim, d_proj=decoder_hidden_size, project=True)
 
         if attention == "bilinear":
             self._decoder_attention = BilinearAttention(decoder_hidden_size, input_dim)

--- a/src/modules/seq2seq_decoder.py
+++ b/src/modules/seq2seq_decoder.py
@@ -68,7 +68,7 @@ class Seq2SeqDecoder(Model):
         self._target_embedder = Embedding(num_classes, self._target_embedding_dim)
 
         # Used to get an initial hidden state from the encoder states
-        self._sent_pooler = Pooler(d_inp=input_dim, d_proj=decoder_hidden_size, project=True)
+        self._sent_pooler = Pooler(project=True, d_inp=input_dim, d_proj=decoder_hidden_size)
 
         if attention == "bilinear":
             self._decoder_attention = BilinearAttention(decoder_hidden_size, input_dim)


### PR DESCRIPTION
Remove pooler `from_params` attribute because it really wasn't that hard to just use the normal constructor and it didn't expose the `pool_type` arg (relevant for BERT).

Refactor pair sentence attention constructor because it was weird.