### PR TITLE
Add tokenizer names to various tasks

### DIFF
--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -428,7 +428,7 @@ def _get_task(name, args, data_path, scratch_path):
             # to pass custom loader args to task.
             task_kw['probe_path'] = args['nli-prob'].probe_path
         if name in ALL_TARG_VOC_TASKS:
-            task_kw['max_targ_v_size'] = args.max_targ_v_size
+            task_kw['max_targ_v_size'] = args.max_targ_word_v_size
         task_src_path = os.path.join(data_path, rel_path)
         task = task_cls(task_src_path, max_seq_len=args.max_seq_len, name=name,
                         tokenizer_name=args.tokenizer, **task_kw)

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -14,7 +14,7 @@ from .registry import REGISTRY
 from .tasks import Task
 
 ##
-# Task lists for handling as a group; these names correspond to the keys in 
+# Task lists for handling as a group; these names correspond to the keys in
 # the task registry.
 ALL_GLUE_TASKS = ['sst', 'cola', 'mrpc', 'qqp', 'sts-b',
                   'mnli', 'qnli', 'rte', 'wnli', 'mnli-diagnostic']
@@ -25,4 +25,5 @@ ALL_NLI_PROBING_TASKS = ['nli-prob', 'nps', 'nli-prob-prepswap', 'nli-prob-negat
 
 # Tasks for which we need to construct task-specific vocabularies
 ALL_TARG_VOC_TASKS = ['wmt17_en_ru', 'wmt14_en_de', 'reddit_s2s',
-                      'reddit_s2s_3.4G', 'reddit_s2s_dummy', 'wiki103_s2s']
+                      'reddit_s2s_3.4G', 'reddit_s2s_dummy',
+                      'wiki103_s2s', 'wiki2_s2s']

--- a/src/tasks/__init__.py
+++ b/src/tasks/__init__.py
@@ -24,6 +24,6 @@ ALL_GLUE_TASKS = ['sst', 'cola', 'mrpc', 'qqp', 'sts-b',
 ALL_NLI_PROBING_TASKS = ['nli-prob', 'nps', 'nli-prob-prepswap', 'nli-prob-negation', 'nli-alt']
 
 # Tasks for which we need to construct task-specific vocabularies
-ALL_TARG_VOC_TASKS = ['wmt17_en_ru', 'wmt14_en_de', 'reddit_s2s',
-                      'reddit_s2s_3.4G', 'reddit_s2s_dummy',
+ALL_TARG_VOC_TASKS = ['wmt17_en_ru', 'wmt14_en_de',
+                      'reddit_s2s', 'reddit_s2s_3.4G',
                       'wiki103_s2s', 'wiki2_s2s']

--- a/src/tasks/lm.py
+++ b/src/tasks/lm.py
@@ -76,7 +76,7 @@ class LanguageModelingTask(SequenceGenerationTask):
                 toks = row.strip()
                 if not toks:
                     continue
-                yield process_sentence(toks, self.max_seq_len)
+                yield process_sentence(toks, self.max_seq_len, tokenizer_name=self._tokenizer_name)
 
     def process_split(self, split, indexers) -> Iterable[Type[Instance]]:
         """Process a language modeling split by indexing and creating fields.
@@ -133,7 +133,8 @@ class WikiTextLMTask(LanguageModelingTask):
                 # WikiText103 preprocesses unknowns as '<unk>'
                 # which gets tokenized as '@', '@', 'UNKNOWN', ...
                 # We replace to avoid that
-                sent = atomic_tokenize(toks, UNK_TOK_ATOMIC, nonatomics_toks, self.max_seq_len)
+                sent = atomic_tokenize(toks, UNK_TOK_ATOMIC, nonatomics_toks, self.max_seq_len,
+                                       tokenizer_name=self._tokenizer_name)
                 # we also filtering out headers (artifact of the data)
                 # which are processed to have multiple = signs
                 if sent.count("=") >= 2 or len(toks) < self.min_seq_len + 2:

--- a/src/tasks/lm.py
+++ b/src/tasks/lm.py
@@ -76,7 +76,7 @@ class LanguageModelingTask(SequenceGenerationTask):
                 toks = row.strip()
                 if not toks:
                     continue
-                yield process_sentence(toks, self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                yield process_sentence(self._tokenizer_name, toks, self.max_seq_len)
 
     def process_split(self, split, indexers) -> Iterable[Type[Instance]]:
         """Process a language modeling split by indexing and creating fields.

--- a/src/tasks/mt.py
+++ b/src/tasks/mt.py
@@ -66,11 +66,9 @@ class MTTask(SequenceGenerationTask):
                 row = row.strip().split('\t')
                 if len(row) < 2 or not row[0] or not row[1]:
                     continue
-                src_sent = process_sentence(row[0], self.max_seq_len,
-                                            tokenizer_name=self._tokenizer_name)
+                src_sent = process_sentence(self._tokenizer_name, row[0], self.max_seq_len)
                 # Currently: force Moses tokenization on targets
-                tgt_sent = process_sentence(row[1], self.max_seq_len,
-                                            tokenizer_name="MosesTokenizer")
+                tgt_sent = process_sentence("MosesTokenizer", row[1], self.max_seq_len)
                 yield (src_sent, tgt_sent)
 
     def get_sentences(self) -> Iterable[Sequence[str]]:
@@ -137,15 +135,13 @@ class RedditSeq2SeqTask(MTTask):
                 row = row.strip().split('\t')
                 if len(row) < 4 or not row[2] or not row[3]:
                     continue
-                src_sent = process_sentence(row[2], self.max_seq_len,
-                                            tokenizer_name=self._tokenizer_name)
-                tgt_sent = process_sentence(row[3], self.max_seq_len,
-                                            tokenizer_name=self._tokenizer_name)
+                src_sent = process_sentence(self._tokenizer_name, row[2], self.max_seq_len)
+                tgt_sent = process_sentence(self._tokenizer_name, row[3], self.max_seq_len)
                 yield (src_sent, tgt_sent)
 
     def process_split(self, split, indexers) -> Iterable[Type[Instance]]:
         ''' Process split text into a list of AllenNLP Instances. '''
-        def _make_instance(input_target):
+        def _make_instance(input, target):
             d = {}
             d["inputs"] = sentence_to_text_field(input, indexers)
             d["targs"] = sentence_to_text_field(target, self.target_indexer)

--- a/src/tasks/mt.py
+++ b/src/tasks/mt.py
@@ -125,7 +125,7 @@ class RedditSeq2SeqTask(MTTask):
                          max_targ_v_size=max_targ_v_size, name=name,
                          **kw)
         self._label_namespace = None
-        self.target_indexer = {"words": SingleIdTokenIndexer()}
+        self.target_indexer = {"words": SingleIdTokenIndexer("tokens")}
         self.files_by_split = {"train": os.path.join(path, "train.csv"),
                                "val": os.path.join(path, "val.csv"),
                                "test": os.path.join(path, "test.csv")}
@@ -167,7 +167,7 @@ class Wiki103Seq2SeqTask(MTTask):
         # Similar for self.target_sentences
         self._nonatomic_toks = [UNK_TOK_ALLENNLP, '<unk>']
         self._label_namespace = None
-        self.target_indexer = {"words": SingleIdTokenIndexer()}
+        self.target_indexer = {"words": SingleIdTokenIndexer("tokens")}
         self.files_by_split = {"train": os.path.join(path, "train.sentences.txt"),
                                "val": os.path.join(path, "valid.sentences.txt"),
                                "test": os.path.join(path, "test.sentences.txt")}

--- a/src/tasks/mt.py
+++ b/src/tasks/mt.py
@@ -41,7 +41,7 @@ class MTTask(SequenceGenerationTask):
         self.max_targ_v_size = max_targ_v_size
         self.target_indexer = {"words": SingleIdTokenIndexer(namespace=self._label_namespace)}
         self.files_by_split = {split: os.path.join(path, "%s.txt" % split) for
-                               split in ["train", "valid", "test"]}
+                               split in ["train", "val", "test"]}
 
     def get_split_text(self, split: str):
         ''' Get split text as iterable of records.
@@ -66,13 +66,11 @@ class MTTask(SequenceGenerationTask):
                 row = row.strip().split('\t')
                 if len(row) < 2 or not row[0] or not row[1]:
                     continue
-                src_sent = process_sentence(row[0], self.max_seq_len)
-                # target sentence sos_tok, eos_tok need to match Seq2SeqDecoder class
-                tgt_sent = process_sentence(
-                    row[1], self.max_seq_len,
-                    sos_tok=allennlp_util.START_SYMBOL,
-                    eos_tok=allennlp_util.END_SYMBOL,
-                )
+                src_sent = process_sentence(row[0], self.max_seq_len,
+                                            tokenizer_name=self._tokenizer_name)
+                # Currently: force Moses tokenization on targets
+                tgt_sent = process_sentence(row[1], self.max_seq_len,
+                                            tokenizer_name="MosesTokenizer")
                 yield (src_sent, tgt_sent)
 
     def get_sentences(self) -> Iterable[Sequence[str]]:
@@ -98,7 +96,7 @@ class MTTask(SequenceGenerationTask):
         def _make_instance(input, target):
             d = {}
             d["inputs"] = sentence_to_text_field(input, indexers)
-            d["targs"] = sentence_to_text_field(target, self.target_indexer)  # this line changed
+            d["targs"] = sentence_to_text_field(target, self.target_indexer)
             return Instance(d)
 
         for sent1, sent2 in split:
@@ -114,9 +112,8 @@ class MTTask(SequenceGenerationTask):
             'unk_ratio_macroavg': unk_ratio_macroavg}
 
 
-@register_task('reddit_s2s', rel_path='Reddit_2008/', max_targ_v_size=0)
+@register_task('reddit_s2s', rel_path='Reddit/', max_targ_v_size=0)
 @register_task('reddit_s2s_3.4G', rel_path='Reddit_3.4G/', max_targ_v_size=0)
-@register_task('reddit_s2s_dummy', rel_path='Reddit_2008_TestSample/', max_targ_v_size=0)
 class RedditSeq2SeqTask(MTTask):
     ''' Task for seq2seq using reddit data
 
@@ -128,7 +125,7 @@ class RedditSeq2SeqTask(MTTask):
                          max_targ_v_size=max_targ_v_size, name=name,
                          **kw)
         self._label_namespace = None
-        self.target_indexer = {"words": SingleIdTokenIndexer("tokens")}
+        self.target_indexer = {"words": SingleIdTokenIndexer()}
         self.files_by_split = {"train": os.path.join(path, "train.csv"),
                                "val": os.path.join(path, "val.csv"),
                                "test": os.path.join(path, "test.csv")}
@@ -140,13 +137,24 @@ class RedditSeq2SeqTask(MTTask):
                 row = row.strip().split('\t')
                 if len(row) < 4 or not row[2] or not row[3]:
                     continue
-                src_sent = process_sentence(row[2], self.max_seq_len)
+                src_sent = process_sentence(row[2], self.max_seq_len,
+                                            tokenizer_name=self._tokenizer_name)
                 tgt_sent = process_sentence(row[3], self.max_seq_len,
-                                            sos_tok=allennlp_util.START_SYMBOL,
-                                            eos_tok=allennlp_util.END_SYMBOL,
-                                            )
+                                            tokenizer_name=self._tokenizer_name)
                 yield (src_sent, tgt_sent)
 
+    def process_split(self, split, indexers) -> Iterable[Type[Instance]]:
+        ''' Process split text into a list of AllenNLP Instances. '''
+        def _make_instance(input_target):
+            d = {}
+            d["inputs"] = sentence_to_text_field(input, indexers)
+            d["targs"] = sentence_to_text_field(target, self.target_indexer)
+            return Instance(d)
+
+        for sent1, sent2 in split:
+            yield _make_instance(sent1, sent2)
+
+@register_task('wiki2_s2s', rel_path='WikiText2/', max_targ_v_size=0)
 @register_task('wiki103_s2s', rel_path='WikiText103/', max_targ_v_size=0)
 class Wiki103Seq2SeqTask(MTTask):
     ''' Skipthought objective on Wiki103 '''
@@ -159,7 +167,7 @@ class Wiki103Seq2SeqTask(MTTask):
         # Similar for self.target_sentences
         self._nonatomic_toks = [UNK_TOK_ALLENNLP, '<unk>']
         self._label_namespace = None
-        self.target_indexer = {"words": SingleIdTokenIndexer("tokens")}
+        self.target_indexer = {"words": SingleIdTokenIndexer()}
         self.files_by_split = {"train": os.path.join(path, "train.sentences.txt"),
                                "val": os.path.join(path, "valid.sentences.txt"),
                                "test": os.path.join(path, "test.sentences.txt")}
@@ -172,8 +180,8 @@ class Wiki103Seq2SeqTask(MTTask):
                 toks = row.strip()
                 if not toks:
                     continue
-                sent = atomic_tokenize(toks, UNK_TOK_ATOMIC, nonatomic_toks,
-                                        self.max_seq_len)
+                sent = atomic_tokenize(toks, UNK_TOK_ATOMIC, nonatomic_toks, self.max_seq_len,
+                                       tokenizer_name=self._tokenizer_name)
                 yield sent, []
 
     def get_num_examples(self, split_text):
@@ -189,12 +197,10 @@ class Wiki103Seq2SeqTask(MTTask):
 
         Split is a single list of sentences here.
         '''
-        target_indexer = self.target_indexer
-
         def _make_instance(prev_sent, sent):
             d = {}
             d["inputs"] = sentence_to_text_field(prev_sent, indexers)
-            d["targs"] = sentence_to_text_field(sent, target_indexer)
+            d["targs"] = sentence_to_text_field(sent, self.target_indexer)
             return Instance(d)
 
         prev_sent = None

--- a/src/tasks/nli_probing.py
+++ b/src/tasks/nli_probing.py
@@ -1,14 +1,11 @@
 """Task definitions for NLI probing tasks."""
 import logging as log
 import os
-
-from ..utils.utils import truncate
-from ..utils.data_loaders import load_tsv, process_sentence
-
 from typing import Iterable, Sequence, List, Dict, Any, Type
 
 from .tasks import PairClassificationTask
 from .registry import register_task
+from ..utils.data_loaders import load_tsv, process_sentence
 
 @register_task('nli-prob', rel_path='NLI-Prob/')
 class NLITypeProbingTask(PairClassificationTask):
@@ -24,12 +21,16 @@ class NLITypeProbingTask(PairClassificationTask):
 
     def load_data(self, path, max_seq_len, probe_path):
         targ_map = {'neutral': 0, 'entailment': 1, 'contradiction': 2}
-        tr_data = load_tsv(os.path.join(path, 'train_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, targ_map=targ_map, skip_rows=0)
-        val_data = load_tsv(os.path.join(path, probe_path), max_seq_len,
-                            s1_idx=0, s2_idx=1, targ_idx=2, targ_map=targ_map, skip_rows=0)
-        te_data = load_tsv(os.path.join(path, 'test_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, targ_map=targ_map, skip_rows=0)
+        label_fn = targ_map.__getitem__
+        tr_data = load_tsv(data_file=os.path.join(path, 'train_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, label_fn=label_fn, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
+        val_data = load_tsv(data_file=os.path.join(path, probe_path), max_seq_len=max_seq_len,
+                            s1_idx=0, s2_idx=1, label_idx=2, label_fn=label_fn, skip_rows=0,
+                            tokenizer_name=self._tokenizer_name)
+        te_data = load_tsv(data_file=os.path.join(path, 'test_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, label_fn=label_fn, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
 
         self.train_data_text = tr_data
         self.val_data_text = val_data
@@ -50,12 +51,17 @@ class NLITypeProbingTaskNeg(PairClassificationTask):
 
     def load_data(self, path, max_seq_len, probe_path):
         targ_map = {'neutral': 0, 'entailment': 1, 'contradiction': 2}
-        tr_data = load_tsv(os.path.join(path, 'train_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, skip_rows=0)
-        val_data = load_tsv(os.path.join(path, 'lexnegs.tsv'), max_seq_len,
-                            s1_idx=8, s2_idx=9, targ_idx=10, targ_map=targ_map, skip_rows=1)
-        te_data = load_tsv(os.path.join(path, 'test_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, skip_rows=0)
+        label_fn = targ_map.__getitem__
+        tr_data = load_tsv(data_file=os.path.join(path, 'train_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
+        # TODO(?): should this use probe_path?
+        val_data = load_tsv(data_file=os.path.join(path, 'lexnegs.tsv'), max_seq_len=max_seq_len,
+                            s1_idx=8, s2_idx=9, label_idx=10, label_fn=label_fn, skip_rows=1,
+                            tokenizer_name=self._tokenizer_name)
+        te_data = load_tsv(data_file=os.path.join(path, 'test_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
 
         self.train_data_text = tr_data
         self.val_data_text = val_data
@@ -75,12 +81,16 @@ class NLITypeProbingTaskPrepswap(PairClassificationTask):
             self.val_data_text[0] + self.val_data_text[1]
 
     def load_data(self, path, max_seq_len, probe_path):
-        tr_data = load_tsv(os.path.join(path, 'train_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, skip_rows=0)
-        val_data = load_tsv(os.path.join(path, 'all.prepswap.turk.newlabels.tsv'), max_seq_len,
-                            s1_idx=8, s2_idx=9, targ_idx=0, skip_rows=0)
-        te_data = load_tsv(os.path.join(path, 'test_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, skip_rows=0)
+        tr_data = load_tsv(data_file=os.path.join(path, 'train_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
+        # TODO(?): should this use probe_path?
+        val_data = load_tsv(data_file=os.path.join(path, 'all.prepswap.turk.newlabels.tsv'),
+                            max_seq_len=max_seq_len, s1_idx=8, s2_idx=9, label_idx=0, skip_rows=0,
+                            tokenizer_name=self._tokenizer_name)
+        te_data = load_tsv(data_file=os.path.join(path, 'test_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
 
         self.train_data_text = tr_data
         self.val_data_text = val_data
@@ -93,28 +103,23 @@ class NLITypeProbingAltTask(NLITypeProbingTask):
 
     def __init__(self, path, max_seq_len, name, probe_path="probe_dummy.tsv",
                  **kw):
-        super(NLITypeProbingTask, self).__init__(name, n_classes=3, **kw)
+        super(NLITypeProbingAltTask, self).__init__(name, n_classes=3, **kw)
         self.load_data(path, max_seq_len, probe_path)
         self.sentences = self.train_data_text[0] + self.train_data_text[1] + \
             self.val_data_text[0] + self.val_data_text[1]
 
     def load_data(self, path, max_seq_len, probe_path):
         targ_map = {'0': 0, '1': 1, '2': 2}
-        tr_data = load_tsv(os.path.join(path, 'train_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, targ_map=targ_map, skip_rows=0)
-        val_data = load_tsv(
-            os.path.join(
-                path,
-                probe_path),
-            max_seq_len,
-            idx_idx=0,
-            s1_idx=9,
-            s2_idx=10,
-            targ_idx=1,
-            targ_map=targ_map,
-            skip_rows=1)
-        te_data = load_tsv(os.path.join(path, 'test_dummy.tsv'), max_seq_len,
-                           s1_idx=1, s2_idx=2, targ_idx=None, targ_map=targ_map, skip_rows=0)
+        label_fn = targ_map.__getitem__
+        tr_data = load_tsv(data_file=os.path.join(path, 'train_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, label_fn=label_fn, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
+        val_data = load_tsv(data_file=os.path.join(path, probe_path), max_seq_len=max_seq_len,
+                            s1_idx=9, s2_idx=10, label_idx=1, label_fn=label_fn, skip_rows=1,
+                            return_indices=True, tokenizer_name=self._tokenizer_name)
+        te_data = load_tsv(data_file=os.path.join(path, 'test_dummy.tsv'), max_seq_len=max_seq_len,
+                           s1_idx=1, s2_idx=2, label_idx=None, label_fn=label_fn, skip_rows=0,
+                           tokenizer_name=self._tokenizer_name)
 
         self.train_data_text = tr_data
         self.val_data_text = val_data

--- a/src/tasks/reddit.py
+++ b/src/tasks/reddit.py
@@ -50,8 +50,8 @@ class RedditTask(RankingTask):
                 row = row.strip().split('\t')
                 if len(row) < 4 or not row[2] or not row[3]:
                     continue
-                sent1 = process_sentence(row[2], self.max_seq_len, tokenizer_name=self._tokenizer_name)
-                sent2 = process_sentence(row[3], self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                sent1 = process_sentence(self._tokenizer_name, row[2], self.max_seq_len)
+                sent2 = process_sentence(self._tokenizer_name, row[3], self.max_seq_len)
                 targ = 1
                 yield (sent1, sent2, targ)
 
@@ -122,8 +122,8 @@ class RedditPairClassificationTask(PairClassificationTask):
                 row = row.strip().split('\t')
                 if len(row) < 4 or not row[2] or not row[3]:
                     continue
-                sent1 = process_sentence(row[2], self.max_seq_len, tokenizer_name=self._tokenizer_name)
-                sent2 = process_sentence(row[3], self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                sent1 = process_sentence(self._tokenizer_name, row[2], self.max_seq_len)
+                sent2 = process_sentence(self._tokenizer_name, row[3], self.max_seq_len)
                 targ = 1
                 yield (sent1, sent2, targ)
 
@@ -186,8 +186,8 @@ class MTDataPairClassificationTask(RedditPairClassificationTask):
                 row = row.strip().split('\t')
                 if len(row) < 2 or not row[0] or not row[1]:
                     continue
-                sent1 = process_sentence(row[0], self.max_seq_len, tokenizer_name=self._tokenizer_name)
-                sent2 = process_sentence(row[1], self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                sent1 = process_sentence(self._tokenizer_name, row[0], self.max_seq_len)
+                sent2 = process_sentence(self._tokenizer_name, row[1], self.max_seq_len)
                 targ = 1
                 yield (sent1, sent2, targ)
 

--- a/src/tasks/reddit.py
+++ b/src/tasks/reddit.py
@@ -50,8 +50,8 @@ class RedditTask(RankingTask):
                 row = row.strip().split('\t')
                 if len(row) < 4 or not row[2] or not row[3]:
                     continue
-                sent1 = process_sentence(row[2], self.max_seq_len)
-                sent2 = process_sentence(row[3], self.max_seq_len)
+                sent1 = process_sentence(row[2], self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                sent2 = process_sentence(row[3], self.max_seq_len, tokenizer_name=self._tokenizer_name)
                 targ = 1
                 yield (sent1, sent2, targ)
 
@@ -93,8 +93,7 @@ class RedditTask(RankingTask):
         acc = self.scorer1.get_metric(reset)
         return {'accuracy': acc}
 
-@register_task('reddit_pair_classif', rel_path='Reddit_2008/')
-@register_task('reddit_pair_classif_dummy', rel_path='Reddit_2008_TestSample/')
+@register_task('reddit_pair_classif', rel_path='Reddit/')
 @register_task('reddit_pair_classif_3.4G', rel_path='Reddit_3.4G/')
 class RedditPairClassificationTask(PairClassificationTask):
     ''' Task class for Reddit data.  '''
@@ -123,8 +122,8 @@ class RedditPairClassificationTask(PairClassificationTask):
                 row = row.strip().split('\t')
                 if len(row) < 4 or not row[2] or not row[3]:
                     continue
-                sent1 = process_sentence(row[2], self.max_seq_len)
-                sent2 = process_sentence(row[3], self.max_seq_len)
+                sent1 = process_sentence(row[2], self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                sent2 = process_sentence(row[3], self.max_seq_len, tokenizer_name=self._tokenizer_name)
                 targ = 1
                 yield (sent1, sent2, targ)
 
@@ -187,8 +186,8 @@ class MTDataPairClassificationTask(RedditPairClassificationTask):
                 row = row.strip().split('\t')
                 if len(row) < 2 or not row[0] or not row[1]:
                     continue
-                sent1 = process_sentence(row[0], self.max_seq_len)
-                sent2 = process_sentence(row[1], self.max_seq_len)
+                sent1 = process_sentence(row[0], self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                sent2 = process_sentence(row[1], self.max_seq_len, tokenizer_name=self._tokenizer_name)
                 targ = 1
                 yield (sent1, sent2, targ)
 

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -1136,8 +1136,8 @@ class DisSentTask(PairClassificationTask):
                 row = row.strip().split('\t')
                 if len(row) != 3 or not (row[0] and row[1] and row[2]):
                     continue
-                sent1 = process_sentence(row[0], self.max_seq_len, tokenizer_name=self._tokenizer_name)
-                sent2 = process_sentence(row[1], self.max_seq_len, tokenizer_name=self._tokenizer_name)
+                sent1 = process_sentence(self._tokenizer_name, row[0], self.max_seq_len)
+                sent2 = process_sentence(self._tokenizer_name, row[1], self.max_seq_len)
                 targ = int(row[2])
                 yield (sent1, sent2, targ)
 

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -55,7 +55,7 @@ def atomic_tokenize(sent: str, atomic_tok: str, nonatomic_toks: List[str], max_s
     with the *first* nonatomic token in the list. '''
     for nonatomic_tok in nonatomic_toks:
         sent = sent.replace(nonatomic_tok, atomic_tok)
-    sent = process_sentence(sent, max_seq_len, tokenizer_name=tokenizer_name)
+    sent = process_sentence(tokenizer_name, sent, max_seq_len)
     sent = [nonatomic_toks[0] if t == atomic_tok else t for t in sent]
     return sent
 
@@ -435,12 +435,12 @@ class CoLAAnalysisTask(SingleClassificationTask):
         # Load data from tsv
         tag_vocab = vocabulary.Vocabulary(counter=None)
         tr_data = load_tsv(tokenizer_name=self._tokenizer_name,
-            data_file=os.path.join(path, "train_analysis.tsv"), max_seq_len=max_seq_len, 
+            data_file=os.path.join(path, "train_analysis.tsv"), max_seq_len=max_seq_len,
             s1_idx=3, s2_idx=None, label_idx=2, skip_rows=1, tag2idx_dict={'Domain': 1}, tag_vocab=tag_vocab)
         val_data = load_tsv(tokenizer_name=self._tokenizer_name,
             data_file=os.path.join(path, "dev_analysis.tsv"), max_seq_len=max_seq_len,
             s1_idx=3, s2_idx=None, label_idx=2, skip_rows=1, tag2idx_dict={
-                'Domain': 1, 'Simple': 4, 'Pred': 5, 'Adjunct': 6, 'Arg Types': 7, 'Arg Altern': 8, 
+                'Domain': 1, 'Simple': 4, 'Pred': 5, 'Adjunct': 6, 'Arg Types': 7, 'Arg Altern': 8,
                 'Imperative': 9, 'Binding': 10, 'Question': 11, 'Comp Clause': 12, 'Auxillary': 13,
                 'to-VP': 14, 'N, Adj': 15, 'S-Syntax': 16, 'Determiner': 17, 'Violations': 18}, tag_vocab=tag_vocab)
         te_data = load_tsv(tokenizer_name=self._tokenizer_name,
@@ -449,7 +449,7 @@ class CoLAAnalysisTask(SingleClassificationTask):
         self.train_data_text = tr_data[:1] + tr_data[2:]
         self.val_data_text = val_data[:1] + val_data[2:]
         self.test_data_text = te_data[:1] + te_data[2:]
-        # Create score for each tag from tag-index dict 
+        # Create score for each tag from tag-index dict
         self.tag_list = get_tag_list(tag_vocab)
         self.tag_scorers1 = create_subset_scorers(count=len(self.tag_list), scorer_type=Correlation, corr_type="matthews")
         self.tag_scorers2 = create_subset_scorers(count=len(self.tag_list), scorer_type=CategoricalAccuracy)
@@ -483,7 +483,7 @@ class CoLAAnalysisTask(SingleClassificationTask):
 
     def get_metrics(self, reset=False):
         '''Get metrics specific to the task'''
-        
+
         collected_metrics = {'mcc': self.scorer1.get_metric(reset), 'accuracy': self.scorer2.get_metric(reset)}
         collected_metrics.update(collect_subset_scores(self.tag_scorers1, 'mcc', self.tag_list, reset))
         collected_metrics.update(collect_subset_scores(self.tag_scorers2, 'accuracy', self.tag_list, reset))


### PR DESCRIPTION
Includes

* Make all tasks use `task._tokenizer_name` when processing data

* Remove removed usage of SOS/EOS tokens in calling `process_sentence`

* Create WikiText 2 skipthought task (mainly for debugging)

* Update comments

* Update some paths