### PR TITLE
Refactoring scorer + update_metrics

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -712,9 +712,7 @@ class MultiTaskModel(nn.Module):
             else:
                 labels = batch['labels'].squeeze(-1)
             out['loss'] = F.cross_entropy(logits, labels)
-            tagmask = None
-            if 'tagmask' in batch:
-                tagmask = batch['tagmask']
+            tagmask = batch.get('tagmask', None)
             task.update_metrics(logits, labels, tagmask=tagmask)
 
         if predict:
@@ -785,9 +783,8 @@ class MultiTaskModel(nn.Module):
         labels = torch.cat([torch.ones(len(sent1)), torch.zeros(len(sent1))])
         labels = torch.tensor(labels, dtype=torch.long).cuda()
         out['loss'] = F.cross_entropy(logits, labels)
-        task.scorer1(logits, labels)
-        if task.scorer2 is not None:
-            task.scorer2(logits, labels)
+        tagmask = batch.get('tagmask', None)
+        task.update_metrics(logits, labels, tagmask=tagmask)
 
         if predict:
             if isinstance(task, RegressionTask):
@@ -827,15 +824,12 @@ class MultiTaskModel(nn.Module):
                 logits = logits.squeeze(-1) if len(logits.size()
                                                    ) > 1 else logits
                 out['loss'] = F.mse_loss(logits, labels)
-                logits_np = logits.data.cpu().numpy()
-                labels_np = labels.data.cpu().numpy()
-                task.scorer1(logits_np, labels_np)
-                task.scorer2(logits_np, labels_np)
+                logits = logits.data.cpu().numpy()
+                labels = labels.data.cpu().numpy()
             else:
                 out['loss'] = F.cross_entropy(logits, labels)
-                task.scorer1(logits, labels)
-                if task.scorer2 is not None:
-                    task.scorer2(logits, labels)
+            tagmask = batch.get('tagmask', None)
+            task.update_metrics(logits, labels, tagmask=tagmask)
 
         if predict:
             if isinstance(task, RegressionTask):

--- a/src/models.py
+++ b/src/models.py
@@ -712,10 +712,10 @@ class MultiTaskModel(nn.Module):
             else:
                 labels = batch['labels'].squeeze(-1)
             out['loss'] = F.cross_entropy(logits, labels)
-            for scorer in task.get_scorers():
-                scorer(logits, labels)
-                if 'tagmask' in batch:
-                    task.update_metrics(logits, labels, tagmask=batch['tagmask'])
+            tagmask = None
+            if 'tagmask' in batch:
+                tagmask = batch['tagmask']
+            task.update_metrics(logits, labels, tagmask=tagmask)
 
         if predict:
             if isinstance(task, RegressionTask):

--- a/src/tasks/mt.py
+++ b/src/tasks/mt.py
@@ -34,6 +34,7 @@ class MTTask(SequenceGenerationTask):
         self.scorer1 = Average()
         self.scorer2 = Average()
         self.scorer3 = Average()
+        self.scorers = [self.scorer1, self.scorer2, self.scorer3]
         self.val_metric = "%s_perplexity" % self.name
         self.val_metric_decreases = True
         self.max_seq_len = max_seq_len

--- a/src/tasks/reddit.py
+++ b/src/tasks/reddit.py
@@ -1,3 +1,4 @@
+
 """Task definitions for reddit."""
 import codecs
 import logging as log
@@ -30,7 +31,7 @@ class RedditTask(RankingTask):
         ''' '''
         super().__init__(name, **kw)
         self.scorer1 = Average()  # CategoricalAccuracy()
-        self.scorer2 = None
+        self.scorers = [self.scorer1]
         self.val_metric = "%s_accuracy" % self.name
         self.val_metric_decreases = False
         self.files_by_split = {split: os.path.join(path, "%s.csv" % split) for
@@ -105,7 +106,6 @@ class RedditPairClassificationTask(PairClassificationTask):
     def __init__(self, path, max_seq_len, name, **kw):
         ''' '''
         super().__init__(name, n_classes=2, **kw)
-        self.scorer2 = None
         self.val_metric = "%s_accuracy" % self.name
         self.val_metric_decreases = False
         self.files_by_split = {split: os.path.join(path, "%s.csv" % split) for

--- a/src/tasks/reddit.py
+++ b/src/tasks/reddit.py
@@ -1,4 +1,3 @@
-
 """Task definitions for reddit."""
 import codecs
 import logging as log

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -458,7 +458,7 @@ class CoLAAnalysisTask(SingleClassificationTask):
         self.val_metric_decreases = False
         self.scorer1 = Correlation("matthews")
         self.scorer2 = CategoricalAccuracy()
-        self.scorers =[self.scorer1, self.scorer2]
+        self.scorers = [self.scorer1, self.scorer2]
 
     def load_data(self, path, max_seq_len):
         '''Load the data'''
@@ -1113,7 +1113,8 @@ class JOCITask(PairOrdinalRegressionTask):
         self.train_data_text = tr_data
         self.val_data_text = val_data
         self.test_data_text = te_data
-
+        log.info("\tFinished loading JOCI data.")
+        
 
 @register_task('wiki103_classif', rel_path='WikiText103/')
 class Wiki103Classification(PairClassificationTask):

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -242,8 +242,8 @@ class Task(object):
         return self.scorers
 
     def update_metrics(self, logits, labels, tagmask=None):
-        assert len(task.get_scorers()) > 0, 'Please specify a score metric'
-        for scorer in task.get_scorers():
+        assert len(self.get_scorers()) > 0, 'Please specify a score metric'
+        for scorer in self.get_scorers():
             scorer(logits, labels)
 
 class ClassificationTask(Task):

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -263,7 +263,7 @@ class SingleClassificationTask(ClassificationTask):
         super().__init__(name, **kw)
         self.n_classes = n_classes
         self.scorer1 = CategoricalAccuracy()
-        self.scorers = [self.subset_scorer]
+        self.scorers = [self.scorer1]
         self.val_metric = "%s_accuracy" % self.name
         self.val_metric_decreases = False
 
@@ -548,6 +548,7 @@ class QQPTask(PairClassificationTask):
         self.sentences = self.train_data_text[0] + self.train_data_text[1] + \
             self.val_data_text[0] + self.val_data_text[1]
         self.scorer2 = F1Measure(1)
+        self.scorers = [self.scorer1, self.scorer2]
         self.val_metric = "%s_acc_f1" % name
         self.val_metric_decreases = False
 
@@ -653,6 +654,7 @@ class MRPCTask(PairClassificationTask):
         self.sentences = self.train_data_text[0] + self.train_data_text[1] + \
             self.val_data_text[0] + self.val_data_text[1]
         self.scorer2 = F1Measure(1)
+        self.scorers = [self.scorer1, self.scorer2]
         self.val_metric = "%s_acc_f1" % name
         self.val_metric_decreases = False
 

--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -238,7 +238,7 @@ class Task(object):
         ''' Get metrics specific to the task. '''
         raise NotImplementedError
 
-    def get_scorers():
+    def get_scorers(self):
         return self.scorers
 
     def update_metrics(self, logits, labels, tagmask=None):
@@ -263,7 +263,7 @@ class SingleClassificationTask(ClassificationTask):
         super().__init__(name, **kw)
         self.n_classes = n_classes
         self.scorer1 = CategoricalAccuracy()
-        self.scorer2 = None
+        self.scorers = [self.subset_scorer]
         self.val_metric = "%s_accuracy" % self.name
         self.val_metric_decreases = False
 
@@ -327,8 +327,6 @@ class PairRegressionTask(RegressionTask):
         ''' Process split text into a list of AllenNLP Instances. '''
         return process_single_pair_task_split(split, indexers, is_pair=True,
                                               classification=False)
-
-
 class PairOrdinalRegressionTask(RegressionTask):
     ''' Generic sentence pair ordinal regression.
         Currently just doing regression but added new class
@@ -354,7 +352,10 @@ class PairOrdinalRegressionTask(RegressionTask):
         ''' Process split text into a list of AllenNLP Instances. '''
         return process_single_pair_task_split(split, indexers, is_pair=True,
                                               classification=False)
-
+    def update_metrics():
+        # currently don't support metrics for regression task
+        # TODO(Yada): support them! 
+        return
 
 class SequenceGenerationTask(Task):
     ''' Generic sentence generation task '''
@@ -372,6 +373,11 @@ class SequenceGenerationTask(Task):
         '''Get metrics specific to the task'''
         bleu = self.scorer1.get_metric(reset)
         return {'bleu': bleu}
+
+    def update_metrics():
+        # currently don't support metrics for regression task
+        # TODO(Yada): support them! 
+        return
 
 
 class RankingTask(Task):
@@ -1105,7 +1111,6 @@ class JOCITask(PairOrdinalRegressionTask):
         self.train_data_text = tr_data
         self.val_data_text = val_data
         self.test_data_text = te_data
-        log.info("\tFinished loading JOCI data.")
 
 
 @register_task('wiki103_classif', rel_path='WikiText103/')


### PR DESCRIPTION
Refactoring scorers to make it more flexible. 
Changes: 
-> Added update_metrics to Task class to allow for flexibility in scorers (moving that logic out of src/models.py to individual tasks) 
-> Added self.subset_scorers to tasks to fit API 

Currently only affects single single sentence tasks and pair sentence classification tasks (non-diagnostic)
Current status:
-Tested on WNLI, STSB, COLA
-Testing on the rest of the affected tasks
