### PR TITLE
Fix typo in modules.py

### DIFF
--- a/src/modules/modules.py
+++ b/src/modules/modules.py
@@ -122,17 +122,17 @@ class SentenceEncoder(Model):
         # Embeddings
         # Note: These highway modules are actually identity functions by
         # default.
+        is_pair_task = isinstance(task, (PairClassificationTask, PairRegressionTask))
 
         # General sentence embeddings (for sentence encoder).
         # Skip this for probing runs that don't need it.
         if not isinstance(self._phrase_layer, NullPhraseLayer):
             if isinstance(self._text_field_embedder, BertEmbedderModule):
-                is_pair_task = isinstance(task, (PairClassificationTask, PairRegressionTask))
-                task_sent_embs = self._text_field_embedder(sent, is_pair_task=is_pair_task)
+                sent_embs = self._text_field_embedder(sent, is_pair_task=is_pair_task)
 
             else:
-                task_sent_embs = self._text_field_embedder(sent)
-            task_sent_embs = self._highway_layer(task_sent_embs)
+                sent_embs = self._text_field_embedder(sent)
+            sent_embs = self._highway_layer(sent_embs)
         else:
             sent_embs = None
 
@@ -140,7 +140,6 @@ class SentenceEncoder(Model):
         # Skip computing this if it won't be used.
         if self.sep_embs_for_skip:
             if isinstance(self._text_field_embedder, BertEmbedderModule):
-                is_pair_task = isinstance(task, (PairClassificationTask, PairRegressionTask))
                 task_sent_embs = self._text_field_embedder(sent, task._classifier_name,
                                                            is_pair_task=is_pair_task)
 


### PR DESCRIPTION
Fix a typo in modules.py (`task_sent_embs` -> `sent_embs`)